### PR TITLE
fix: Correct field name in DriverSerializer

### DIFF
--- a/backend/apps/gatepass/serializers.py
+++ b/backend/apps/gatepass/serializers.py
@@ -31,7 +31,7 @@ class DriverSerializer(serializers.ModelSerializer):
     class Meta:
         model = Driver
         # Ensure these fields match your Driver model's actual fields for display
-        fields = ['id', 'name', 'phone_number']
+        fields = ['id', 'name', 'contact_details']
 
 class SimpleUserSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
This commit fixes an `ImproperlyConfigured` error that occurred because the `DriverSerializer` was trying to serialize a field named `phone_number`, but the `Driver` model has a field named `contact_details`.

The `DriverSerializer` has been updated to use the correct field name.