### PR TITLE
fix: Fix ElevatedButton theme

### DIFF
--- a/frontend/gatepass_app/lib/main.dart
+++ b/frontend/gatepass_app/lib/main.dart
@@ -61,6 +61,8 @@ class MyApp extends StatelessWidget {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(10),
             ),
+            backgroundColor: Colors.blueGrey,
+            foregroundColor: Colors.white,
           ),
         ),
         inputDecorationTheme: InputDecorationTheme(


### PR DESCRIPTION
This commit fixes an issue where the text of an `ElevatedButton` was not visible when the button was clicked. This was because the `foregroundColor` was not specified in the `elevatedButtonTheme`.

The `elevatedButtonTheme` has been updated to include a `foregroundColor` and a `backgroundColor`.