### PR TITLE
fix: Fix sort icon color

### DIFF
--- a/frontend/gatepass_app/lib/presentation/my_passes/my_passes_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/my_passes/my_passes_screen.dart
@@ -243,7 +243,7 @@ class _MyPassesScreenState extends State<MyPassesScreen> {
           _buildFilterButton('PENDING', Icons.hourglass_empty),
           _buildFilterButton('REJECTED', Icons.cancel),
           IconButton(
-            icon: Icon(Icons.sort),
+            icon: Icon(Icons.sort, color: _isSortedByDate ? Theme.of(context).primaryColor : Colors.grey),
             onPressed: _sortPasses,
           ),
         ],


### PR DESCRIPTION
This commit fixes an issue where the sort icon color was not changing when the sort order was changed.

The `_buildFilterBar` method has been updated to apply the correct color to the sort icon.